### PR TITLE
Removes an endpoint to restart erddap

### DIFF
--- a/ooiservices/routes.py
+++ b/ooiservices/routes.py
@@ -18,7 +18,6 @@ from ooiservices.controller.instrument_deployment import InstrumentDeploymentCon
 from ooiservices.controller.platform_deployment import PlatformDeploymentController, PlatformDeploymentListController, initialize_model as initialize_platform_deployment
 from ooiservices.controller.stream import StreamListController, StreamController
 from ooiservices.controller.parameter import ParameterListController
-from ooiservices.generate_catalog import service_generate_catalog
 
 
 # initialize model
@@ -53,10 +52,3 @@ api.add_resource(StreamListController, '/streams')
 api.add_resource(StreamController, '/streams/<string:id>')
 
 api.add_resource(ParameterListController, '/parameters')
-
-@app.route('/generate_catalog')
-def generate_catalog():
-    service_generate_catalog()
-    response = Response(response='{"status":"ok"}', status=200)
-    return response
-


### PR DESCRIPTION
- It does not belong in services
- We need to move ALL ERDDAP management software out of this repo and
  into a new python module.
