### PR TITLE
Updates the README to deal with role missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,19 @@ Make sure you have the environment variables defiend:
     PYTHONPATH=.
     
 Setup the Database:
-    python ooiuiservice/manage.py deploy --password <admin-password>
+    python ooiservices/manage.py deploy --password <admin-password>
 
+
+### Debugging Database Problems
+
+If you attempt to deploy the database `ooiservices/manage.py deploy` and
+encounter an error "role postgres does not exist". You need to create the role
+postgres. You can do so by
+
+```
+psql postgres
+CREATE ROLE postgres LOGIN SUPERUSER;
+```
 
 ### Running the services instance
     python ooiservices/manage.py runserver


### PR DESCRIPTION
Some newer instances of Postgres don't actually install the role
"postgres". In these newer instances, we'll have to have our developers
create the role manually, so I've included it in the README