### PR TITLE
Update uFrame URL port number

### DIFF
--- a/ooiservices/app/config.yml
+++ b/ooiservices/app/config.yml
@@ -12,7 +12,7 @@ COMMON: &common
     HOST: localhost
     PORT: 4000
     JSONIFY_PRETTYPRINT_REGULAR: true
-    UFRAME_URL: 'http://localhost:12570'
+    UFRAME_URL: 'http://localhost:12575'
     UFRAME_ASSETS_URL: 'http://localhost:12573'
     UFRAME_URL_BASE: '/sensor/inv'
     REDMINE_KEY: 'XXXXXXXXXXXXX'


### PR DESCRIPTION
Updates `UFRAME_URL` to use port 12575 instead of 12570, which appears
to be what uFrame is actually running on for the most recent uFrame Cassandra VM as of this writing.  Production and other servers, etc
which may use a different uFrame version/port should be checked prior to
using this commit.