### PR TITLE
Mc toc

### DIFF
--- a/ooiservices/app/uframe/assetController.py
+++ b/ooiservices/app/uframe/assetController.py
@@ -309,6 +309,12 @@ class uFrameAssetCollection(object):
             }
             temp_metaData.append(dict_platform)
 
+        #TODO:
+        #temp_metaData needs to be checked against the existing metaData and
+        #appended or updated as necessary.  For now, temp_metaData goes no where
+        #, as it would over write the existing values.
+
+
         #Below section's keys are uFrame specific and shouldn't be modified
         #unless necessary to support uframe updates.
         formatted_return = {
@@ -578,6 +584,8 @@ def create_asset():
 
 #Update
 #@auth.login_required
+#mjc 03/30/2015
+#TODO: PUT Disabled due to data loss associated with metaData not being returned.
 #@api.route('/assets/<int:id>', methods=['PUT'])
 def update_asset(id):
     '''
@@ -661,8 +669,10 @@ def create_event():
     return response.text
 
 #Update
+#mjc 03/30/2015
+#TODO: PUT Disabled due to data loss associated with metaData not being returned.
 @auth.login_required
-@api.route('/events/<int:id>', methods=['PUT'])
+#@api.route('/events/<int:id>', methods=['PUT'])
 def update_event(id):
     '''
     Update an existing event, the return will be right from uframe if all goes well.


### PR DESCRIPTION
Note the "stream_url", all assets returned from /uframe/assets will be checked against the data port (12575) to see if it actually contains usable data.  If there is no data, this key will be omitted.

@DanielJMaher , @birdage, @oceanzus : 
This is a NON lazy load approach, and I feel this is sufficient to populate the TOC with usable data suited for the content page.  The way uframe is now, there is no logical hierarchal grouping possible in the TOC...only the ability to display relevant/usable assets.

This commit also disables PUT for assets and events until it's correctly sorted out.  Don't want to accidentally overwrite any data.

What do you think?

```
"assets": [
    {
      "assetId": 3, 
      "assetInfo": {
        "description": null, 
        "name": null, 
        "owner": null, 
        "type": "Mooring"
      }, 
      "attachments": [], 
      "class": ".AssetRecord", 
      "coordinates": [
        40.2268667, 
        -70.8889333
      ], 
      "launch_date_time": "16-Apr-14 23:28", 
      "manufactureInfo": {
        "manufacturer": null, 
        "modelNumber": null, 
        "serialNumber": "CP02PMCI-00001"
      }, 
      "notes": [], 
      "ref_des": "CP02PMCI", 
      "stream_url": "http://uframe-test.ooi.rutgers.edu:12575/sensor/inv/CP02PMCI", 
      "uframe_url": "http://localhost:12573/assets/3", 
      "url": "/uframe/assets/3", 
      "water_depth": {
        "unit": "m", 
        "value": 127.0
      }
    },
```