### PR TITLE
Updates cache: If uframe is down, do not cache the error message.

### DIFF
--- a/ooiservices/app/uframe/assetController.py
+++ b/ooiservices/app/uframe/assetController.py
@@ -520,8 +520,8 @@ def get_assets():
         pass
 
     result = jsonify({ 'assets' : data })
-    cache.set('asset_list', result, timeout=CACHE_TIMEOUT)
-
+    if "error" not in data:
+        cache.set('asset_list', result, timeout=CACHE_TIMEOUT)
     return result
 
 #Read (object)
@@ -679,7 +679,8 @@ def get_events():
         pass
 
     result = jsonify({ 'events' : data })
-    cache.set('event_list', result, timeout=CACHE_TIMEOUT)
+    if "error" not in data:
+        cache.set('event_list', result, timeout=CACHE_TIMEOUT)
 
     return result
 


### PR DESCRIPTION
@DanielJMaher @oceanzus , So you're not sitting around waiting for the cache to clear after getting a uframe error message.