### PR TITLE
/uframe/events/<string:ref_des> 

### DIFF
--- a/ooiservices/app/uframe/assetController.py
+++ b/ooiservices/app/uframe/assetController.py
@@ -721,8 +721,8 @@ def get_events_by_ref_des(ref_des):
         return cached
 
     #Create the container for the processed response
-    result = {}
-
+    result = []
+    temp_dict = {}
     #variables used in loop
     platform = ""
     mooring = ""
@@ -740,19 +740,21 @@ def get_events_by_ref_des(ref_des):
             if row['referenceDesignator']['sensor'] is not None:  
                 instrument = row['referenceDesignator']['sensor']
             concat_ref_des =  '-'.join([platform, mooring, instrument])
+            print concat_ref_des
             if concat_ref_des == ref_des:
-                result['ref_des'] = concat_ref_des
-                result['start_date'] = row['startDate']
-                result['class'] = row['@class']
-                result['event_description'] = row['eventDescription']
-                result['event_type'] = row['eventType']
-                result['notes'] = row['notes']
-                result['url'] =  url_for('uframe.get_event', id=row['eventId'])
-                result['uframe_url'] = current_app.config['UFRAME_ASSETS_URL'] + '/%s/%s' % (uframe_obj.__endpoint__, row['eventId'])
+                temp_dict['ref_des'] = concat_ref_des
+                temp_dict['start_date'] = row['startDate']
+                temp_dict['class'] = row['@class']
+                temp_dict['event_description'] = row['eventDescription']
+                temp_dict['event_type'] = row['eventType']
+                temp_dict['notes'] = row['notes']
+                temp_dict['url'] =  url_for('uframe.get_event', id=row['eventId'])
+                temp_dict['uframe_url'] = current_app.config['UFRAME_ASSETS_URL'] + '/%s/%s' % (uframe_obj.__endpoint__, row['eventId'])
+                result.append(temp_dict)
         except:
-            print "nope! %s, %s" % (concat_ref_des, ref_des)
-    
-    return jsonify(**result)
+            pass 
+    result = jsonify({ 'events' : result })
+    return result
 
 
 #Create

--- a/ooiservices/app/uframe/assetController.py
+++ b/ooiservices/app/uframe/assetController.py
@@ -740,7 +740,6 @@ def get_events_by_ref_des(ref_des):
             if row['referenceDesignator']['sensor'] is not None:  
                 instrument = row['referenceDesignator']['sensor']
             concat_ref_des =  '-'.join([platform, mooring, instrument])
-            print concat_ref_des
             if concat_ref_des == ref_des:
                 temp_dict['ref_des'] = concat_ref_des
                 temp_dict['start_date'] = row['startDate']

--- a/ooiservices/app/uframe/assetController.py
+++ b/ooiservices/app/uframe/assetController.py
@@ -751,6 +751,7 @@ def get_events_by_ref_des(ref_des):
                 temp_dict['url'] =  url_for('uframe.get_event', id=row['eventId'])
                 temp_dict['uframe_url'] = current_app.config['UFRAME_ASSETS_URL'] + '/%s/%s' % (uframe_obj.__endpoint__, row['eventId'])
                 result.append(temp_dict)
+                temp_dict = ""
         except:
             pass 
     result = jsonify({ 'events' : result })


### PR DESCRIPTION
@Bobfrat , @DanielJMaher 

This route will return the following format if used as follows (example):

```
http://localhost:4000/uframe/events/CP05MOAS-GL004-01-ADCPAM000
HTTP/1.0 200 OK
Access-Control-Allow-Origin: *
Content-Length: 660
Content-Type: application/json
Date: Wed, 29 Apr 2015 18:19:29 GMT
Server: Werkzeug/0.9.6 Python/2.7.9
Set-Cookie: session=***
```
```
{
    "events": [
        {
            "class": ".DeploymentEvent", 
            "event_description": null, 
            "event_type": "ACTUAL", 
            "notes": [], 
            "ref_des": "CP05MOAS-GL004-01-ADCPAM000", 
            "start_date": 1412643960000, 
            "uframe_url": "http://uframe-test.ooi.rutgers.edu:12573/events/32", 
            "url": "/uframe/events/32"
        }
    ]
}