### PR TITLE
handling for situations where there is no tense

### DIFF
--- a/ooiservices/app/uframe/assetController.py
+++ b/ooiservices/app/uframe/assetController.py
@@ -284,7 +284,7 @@ def associate_events(id):
             d['notes'] = len(row['notes'])
             d['startDate'] = row['startDate']
             d['endDate'] = row['endDate']
-            d['tense'] = row['tense']
+            d['tense'] = row['tense'] or ""
             if d['eventClass'] == '.CalibrationEvent':
                 d['calibrationCoefficient'] = row['calibrationCoefficient']
                 lon = 0.0


### PR DESCRIPTION
@DanielJMaher Looks like people are creating events w/o tenses somehow, and the assets aren't getting their associated event tense - this sets the default (to null) if it's absent.

Saw 500 error coming out of this this morning.