### PR TITLE
Add UUID to error message

### DIFF
--- a/ooiservices/app/uframe/controller.py
+++ b/ooiservices/app/uframe/controller.py
@@ -935,6 +935,7 @@ def get_uframe_plot_contents_chunked(mooring, platform, instrument, stream_type,
         CHUNK_SIZE = 1024 * 32   #...KB
         TOTAL_SECONDS = current_app.config['UFRAME_PLOT_TIMEOUT']
         dataBlock = ""
+        response = ""
         idx = 0
 
         # counter
@@ -975,7 +976,8 @@ def map_common_error_message(response, default):
     '''
     message = default
     if 'requestUUID' in response:
-        message = 'Error Occurred During Product Creation'
+        UUID = response.split('requestUUID":')[1].split('"')[1]
+        message = 'Error Occurred During Product Creation<br>UUID for reference: ' + UUID
     elif 'Failed to respond' in response:
         message = 'Internal System Error in Data Repository'
 


### PR DESCRIPTION
@FBRTMaka @DanielJMaher 
Adds the UUID to the error message:
![screen shot 2016-01-26 at 11 56 49 am](https://cloud.githubusercontent.com/assets/5702672/12587843/e8af6c22-c423-11e5-9250-f42edc2ea4dc.png)
